### PR TITLE
Feature/deployer 7.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,15 +10,15 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
-        "deployer/deployer": "^6.8",
-        "symfony/finder": "^4.4 || ^5.4 || ^6.0",
+        "php": ">=8.2",
+        "deployer/deployer": "^7.5",
+        "symfony/finder": "^7.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.18",
-        "setono/code-quality-pack": "^2.4"
+        "phpunit/phpunit": "^10.5",
+        "psalm/plugin-phpunit": "^0.19",
+        "setono/code-quality-pack": "^2.8"
     },
     "prefer-stable": true,
     "autoload": {

--- a/src/recipe/setono_supervisor.php
+++ b/src/recipe/setono_supervisor.php
@@ -12,6 +12,6 @@ require_once 'task/setono_supervisor.php';
 before('supervisor:upload', 'supervisor:stop');
 before('deploy:symlink', 'supervisor:upload');
 
-after('success', 'supervisor:start');
+after('deploy:success', 'supervisor:start');
 after('deploy:failed', 'supervisor:start');
 after('rollback', 'supervisor:start');

--- a/src/task/setono_supervisor.php
+++ b/src/task/setono_supervisor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Setono\Deployer\Supervisor;
 
 use function Deployer\get;
-use function Deployer\locateBinaryPath;
+use function Deployer\which;
 use function Deployer\run;
 use function Deployer\set;
 use function Deployer\task;
@@ -17,7 +17,7 @@ use Webmozart\Assert\Assert;
  * The supervisor(ctl) binary
  */
 set('bin/supervisor', static function (): string {
-    $binary = locateBinaryPath('supervisorctl');
+    $binary = which('supervisorctl');
     Assert::string($binary);
 
     return $binary;

--- a/src/task/setono_supervisor.php
+++ b/src/task/setono_supervisor.php
@@ -115,3 +115,7 @@ task('supervisor:start', static function (): void {
         run('{{bin/supervisor}} start all');
     }
 })->desc('Starts all services managed by Supervisor');
+
+task('supervisor:install', function () {
+    run('apt-get install -y supervisor', env: ['DEBIAN_FRONTEND' => 'noninteractive'], timeout: 900);
+})->desc('Installs supervisor on the host');


### PR DESCRIPTION
Adds support for deployer 7.5. I also added a command to install `supervisor`.

I know 8 just came out but it looks like 7.5 is still the stable/default on packagist as 8 is in alpha.